### PR TITLE
v0.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 pkg/*.gem
+codecov.yml
 coverage/
 .coveralls.yml
 .bundle

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ implicitcad_watcher
 
 [![Gem Version](https://img.shields.io/gem/v/implicitcad_watcher.svg)](https://rubygems.org/gems/implicitcad_watcher)
 [![CI](https://github.com/aerickson/implicitcad_watcher/actions/workflows/main.yml/badge.svg)](https://github.com/aerickson/implicitcad_watcher/actions/workflows/main.yml)
+[![codecov](https://codecov.io/gh/aerickson/implicitcad_watcher/graph/badge.svg?token=Yj3DgnEeum)](https://codecov.io/gh/aerickson/implicitcad_watcher)
 [![MIT Licensed](https://img.shields.io/badge/license-MIT-green.svg)](https://tldrlegal.com/license/mit-license)
 
 ## overview

--- a/bin/implicitcad_watcher
+++ b/bin/implicitcad_watcher
@@ -7,9 +7,8 @@ trap("SIGINT") { puts "\nCtrl-C received. Exiting."; exit 130 }
 CadWatcher.main(
   {
     bin_name: "extopenscad",
-    # bin_paths: [File.expand_path("~/.cabal/bin/extopenscad")],
-    file_globs: ["*.escad"],
-    file_regex: /\.escad$/,
+    filetype_globs: ["*.escad"],
+    watch_globs: ["**/*.escad"],
     render_cmd_template: ->(bin, src, dest) { "#{bin} -f stl -o \"#{dest}\" \"#{src}\"" },
     debug_mode: false
   }

--- a/bin/openscad_watcher
+++ b/bin/openscad_watcher
@@ -7,7 +7,7 @@ trap("SIGINT") { puts "\nCtrl-C received. Exiting."; exit 130 }
 CadWatcher.main(
   {
     bin_glob: ["/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD", "/Applications/OpenSCAD*.app/Contents/MacOS/OpenSCAD"],
-    filetype_globs: ["*.scad"],
+    filetype_globs: ["*.scad", "*.escad"],
     render_cmd_template: ->(bin, src, dest) { "#{bin} -o \"#{dest}\" \"#{src}\"" },
     debug_mode: true
   }

--- a/bin/openscad_watcher
+++ b/bin/openscad_watcher
@@ -7,8 +7,7 @@ trap("SIGINT") { puts "\nCtrl-C received. Exiting."; exit 130 }
 CadWatcher.main(
   {
     bin_glob: ["/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD", "/Applications/OpenSCAD*.app/Contents/MacOS/OpenSCAD"],
-    file_globs: ["*.scad"],
-    file_regex: /\.[e]*scad$/,
+    filetype_globs: ["*.scad"],
     render_cmd_template: ->(bin, src, dest) { "#{bin} -o \"#{dest}\" \"#{src}\"" },
     debug_mode: true
   }

--- a/lib/cad_watcher.rb
+++ b/lib/cad_watcher.rb
@@ -111,7 +111,7 @@ class CadWatcher
       end
     end
 
-    raise "CAD binary not found. Searched bin_name: #{bin_name.inspect}, paths: #{bin_paths.inspect}, globs: #{bin_glob.inspect}"
+    raise "Binary not found. Searched bin_name: #{bin_name.inspect}, paths: #{bin_paths.inspect}, globs: #{bin_glob.inspect}"
   end
 
   def debug(msg)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,4 +1,4 @@
     # lib/implicitcad_watcher/version.rb
     module ImplicitcadWatcher
-      VERSION = "0.0.3"
+      VERSION = "0.1.0"
     end

--- a/spec/implicitcad_watcher_spec.rb
+++ b/spec/implicitcad_watcher_spec.rb
@@ -2,21 +2,21 @@ require "spec_helper"
 
 describe CadWatcher do
   let(:dummy_bin) { "/bin/echo" }
-  let(:file_globs) { ["test/*.escad"] }
-  let(:file_regex) { /\.escad$/ }
+  let(:filetype_globs) { ["test/*.escad"] }
+  let(:watch_globs) { ["test/*.escad"] }
   let(:render_cmd_template) { ->(bin, src, dest) { "#{bin} #{src} #{dest}" } }
 
   describe "#initialize" do
     it "sets attributes correctly" do
       watcher = CadWatcher.new(
         bin_paths: [dummy_bin],
-        file_globs: file_globs,
-        file_regex: file_regex,
+        filetype_globs: filetype_globs,
+        watch_globs: watch_globs,
         render_cmd_template: render_cmd_template,
         debug_mode: true
       )
-      expect(watcher.file_globs).to eq(file_globs)
-      expect(watcher.file_regex).to eq(file_regex)
+      expect(watcher.filetype_globs).to eq(filetype_globs)
+      expect(watcher.watch_globs).to eq(watch_globs)
       expect(watcher.render_cmd_template).to eq(render_cmd_template)
       expect(watcher.debug_mode).to eq(true)
     end
@@ -26,8 +26,8 @@ describe CadWatcher do
     it "returns .stl file path for a given source file" do
       watcher = CadWatcher.new(
         bin_paths: [dummy_bin],
-        file_globs: file_globs,
-        file_regex: file_regex,
+        filetype_globs: filetype_globs,
+        watch_globs: watch_globs,
         render_cmd_template: render_cmd_template
       )
       expect(watcher.get_result_file("foo/bar/test.escad")).to eq("foo/bar/test.stl")
@@ -46,8 +46,8 @@ describe CadWatcher do
     it "runs the render command for each file" do
       watcher = CadWatcher.new(
         bin_paths: [dummy_bin],
-        file_globs: file_globs,
-        file_regex: file_regex,
+        filetype_globs: filetype_globs,
+        watch_globs: watch_globs,
         render_cmd_template: render_cmd_template
       )
       files = ["test/test.escad"]
@@ -66,7 +66,7 @@ describe CadWatcher do
       watcher = CadWatcher.allocate
       expect {
         watcher.send(:find_bin, "nonexistent_binary", [], nil)
-      }.to raise_error(/CAD binary not found/)
+      }.to raise_error(/Binary not found/)
     end
   end
 end

--- a/spec/implicitcad_watcher_spec.rb
+++ b/spec/implicitcad_watcher_spec.rb
@@ -83,4 +83,37 @@ describe CadWatcher do
       watcher.first_run
     end
   end
+
+  describe "#glob_to_regexp" do
+    let(:watcher) {
+      CadWatcher.new(
+        bin_paths: [dummy_bin],
+        filetype_globs: filetype_globs,
+        watch_globs: watch_globs,
+        render_cmd_template: render_cmd_template
+      )
+    }
+
+    it "converts '*' to match any characters" do
+      re = watcher.send(:glob_to_regexp, "*.escad")
+      expect("foo.escad").to match(re)
+      expect("bar.escad").to match(re)
+      expect("foo.txt").not_to match(re)
+    end
+
+    it "escapes dots and matches literal dots" do
+      re = watcher.send(:glob_to_regexp, "test.*.escad")
+      expect("test.foo.escad").to match(re)
+      expect("test..escad").to match(re)
+      expect("testescad").not_to match(re)
+    end
+
+    it "matches the whole string (anchors)" do
+      re = watcher.send(:glob_to_regexp, "foo.*")
+      expect("foo.bar").to match(re)
+      expect("foo.bar.baz").to match(re)
+      expect("afoo.bar").not_to match(re)
+      expect("foo.bar.baz.txt").to match(re)
+    end
+  end
 end

--- a/spec/implicitcad_watcher_spec.rb
+++ b/spec/implicitcad_watcher_spec.rb
@@ -69,4 +69,18 @@ describe CadWatcher do
       }.to raise_error(/Binary not found/)
     end
   end
+
+  describe "#first_run" do
+    it "calls run with files matching filetype_globs and watch_globs" do
+      watcher = CadWatcher.new(
+        bin_paths: [dummy_bin],
+        filetype_globs: ["test/*.escad"],
+        watch_globs: ["test/*.escad"],
+        render_cmd_template: render_cmd_template
+      )
+      allow(Dir).to receive(:glob).with("test/*.escad").and_return(["test/test.escad", "test/haha.escad", "test/ignore.txt"])
+      expect(watcher).to receive(:run).with(["test/test.escad", "test/haha.escad"])
+      watcher.first_run
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,5 +7,13 @@ if ENV["CI"] == "true"
   end
 end
 
+if ENV["COV"] == "true"
+  require "simplecov"
+  SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
+  SimpleCov.start do
+    add_filter "/spec/"
+  end
+end
+
 require "rspec"
 require "cad_watcher"


### PR DESCRIPTION
- files to monitor can be specified (vs all matched file types)
- internal refactoring
  - store only globs internally (no regex)
- more tests
- fix: openscadwatcher looks at escad flies again